### PR TITLE
add script and queries to produce daily histograms by continent-country-region-year

### DIFF
--- a/statistics/queries/continent_country_region_histogram.sql
+++ b/statistics/queries/continent_country_region_histogram.sql
@@ -1,0 +1,317 @@
+WITH
+# Select the initial set of results
+dl_per_location AS (
+  SELECT
+    test_date,
+    client.Geo.continent_code AS continent_code,
+    client.Geo.country_code AS country_code,
+    client.Geo.country_name AS country_name,
+    CONCAT(client.Geo.country_code, '-', client.Geo.region) AS ISO3166_2region1,
+    a.MeanThroughputMbps AS mbps,
+    NET.SAFE_IP_FROM_STRING(Client.IP) AS ip
+  FROM `measurement-lab.ndt.unified_downloads`
+  WHERE test_date = @startday
+),
+# With good locations and valid IPs
+dl_per_location_cleaned AS (
+  SELECT
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    mbps,
+    ip
+  FROM dl_per_location
+  WHERE 
+    continent_code IS NOT NULL AND continent_code != ""
+    AND country_code IS NOT NULL AND country_code != ""
+    AND country_name IS NOT NULL AND country_name != ""
+    AND ISO3166_2region1 IS NOT NULL AND ISO3166_2region1 != ""
+    AND ip IS NOT NULL
+),
+# Gather descriptive statistics per geo, day, per ip
+dl_stats_perip_perday AS (
+  SELECT
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    ip,
+    MIN(mbps) AS MIN_download_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_download_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS MED_download_Mbps,
+    AVG(mbps) AS MEAN_download_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_download_Mbps,
+    MAX(mbps) AS MAX_download_Mbps
+  FROM dl_per_location_cleaned
+  GROUP BY test_date, continent_code, country_code, country_name, ISO3166_2region1, ip
+),
+# Calculate final stats per day from 1x test per ip per day normalization in prev. step
+dl_stats_per_day AS (
+  SELECT 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    MIN(MIN_download_Mbps) AS MIN_download_Mbps,
+    APPROX_QUANTILES(LOWER_QUART_download_Mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_download_Mbps,
+    APPROX_QUANTILES(MED_download_Mbps, 100) [SAFE_ORDINAL(50)] AS MED_download_Mbps,
+    AVG(MEAN_download_Mbps) AS MEAN_download_Mbps,
+    APPROX_QUANTILES(UPPER_QUART_download_Mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_download_Mbps,
+    MAX(MAX_download_Mbps) AS MAX_download_Mbps
+  FROM
+    dl_stats_perip_perday
+  GROUP BY test_date, continent_code, country_code, country_name, ISO3166_2region1
+),
+dl_total_samples_per_geo AS (
+  SELECT
+    test_date,
+    COUNT(*) AS dl_total_samples,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1
+  FROM dl_per_location_cleaned
+  GROUP BY test_date, continent_code, country_code, country_name, ISO3166_2region1
+),
+# Now generate daily histograms of Max DL Maximum measured value per IP, per day 
+max_dl_per_day_ip AS (
+  SELECT 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    ip,
+    MAX(mbps) AS mbps
+  FROM dl_per_location_cleaned
+  GROUP BY 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    ip
+),
+# Count the samples
+dl_sample_counts AS (
+  SELECT 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    COUNT(*) AS samples
+  FROM max_dl_per_day_ip
+  GROUP BY
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1  
+),
+# Generate equal sized buckets in log-space
+buckets AS (
+  SELECT POW(10,x) AS bucket_right, POW(10, x-.2) AS bucket_left
+  FROM UNNEST(GENERATE_ARRAY(0, 4.2, .2)) AS x
+),
+# Count the samples that fall into each bucket
+dl_histogram_counts AS (
+  SELECT 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(mbps < bucket_right AND mbps >= bucket_left) AS bucket_count
+  FROM max_dl_per_day_ip CROSS JOIN buckets
+  GROUP BY 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    bucket_min,
+    bucket_max
+),
+# Turn the counts into frequencies
+dl_histogram AS (
+  SELECT 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1, 
+    bucket_min,
+    bucket_max,
+    bucket_count / samples AS dl_frac,
+    samples AS dl_samples
+  FROM dl_histogram_counts 
+  JOIN dl_sample_counts USING (test_date, continent_code, country_code,
+                            country_name, ISO3166_2region1)
+),
+# Repeat for Upload tests
+# Select the initial set of upload results
+ul_per_location AS (
+  SELECT
+    test_date,
+    client.Geo.continent_code AS continent_code,
+    client.Geo.country_code AS country_code,
+    client.Geo.country_name AS country_name,
+    CONCAT(client.Geo.country_code, '-', client.Geo.region) AS ISO3166_2region1,
+    a.MeanThroughputMbps AS mbps,
+    NET.SAFE_IP_FROM_STRING(Client.IP) AS ip
+  FROM `measurement-lab.ndt.unified_uploads`
+  WHERE test_date = @startday
+),
+# With good locations and valid IPs
+ul_per_location_cleaned AS (
+  SELECT
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    mbps,
+    ip
+  FROM ul_per_location
+  WHERE 
+    continent_code IS NOT NULL AND continent_code != ""
+    AND country_code IS NOT NULL AND country_code != ""
+    AND country_name IS NOT NULL AND country_name != ""
+    AND ISO3166_2region1 IS NOT NULL AND ISO3166_2region1 != ""
+    AND ip IS NOT NULL
+),
+# Gather descriptive statistics per geo, day, per ip
+ul_stats_perip_perday AS (
+  SELECT
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    ip,
+    MIN(mbps) AS MIN_upload_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_upload_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(50)] AS MED_upload_Mbps,
+    AVG(mbps) AS MEAN_upload_Mbps,
+    APPROX_QUANTILES(mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_upload_Mbps,
+    MAX(mbps) AS MAX_upload_Mbps
+  FROM dl_per_location_cleaned
+  GROUP BY test_date, continent_code, country_code, country_name, ISO3166_2region1, ip
+),
+# Calculate final stats per day from 1x test per ip per day normalization in prev. step
+ul_stats_per_day AS (
+  SELECT 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    MIN(MIN_upload_Mbps) AS MIN_upload_Mbps,
+    APPROX_QUANTILES(LOWER_QUART_upload_Mbps, 100) [SAFE_ORDINAL(25)] AS LOWER_QUART_upload_Mbps,
+    APPROX_QUANTILES(MED_upload_Mbps, 100) [SAFE_ORDINAL(50)] AS MED_upload_Mbps,
+    AVG(MEAN_upload_Mbps) AS MEAN_upload_Mbps,
+    APPROX_QUANTILES(UPPER_QUART_upload_Mbps, 100) [SAFE_ORDINAL(75)] AS UPPER_QUART_upload_Mbps,
+    MAX(MAX_upload_Mbps) AS MAX_upload_Mbps
+  FROM
+    ul_stats_perip_perday
+  GROUP BY test_date, continent_code, country_code, country_name, ISO3166_2region1
+),
+ul_total_samples_per_geo AS (
+  SELECT
+    test_date,
+    COUNT(*) AS ul_total_samples,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1
+  FROM ul_per_location_cleaned
+  GROUP BY test_date, continent_code, country_code, country_name, ISO3166_2region1
+),
+# Now generate daily histograms of Max DL Maximum measured value per IP, per day 
+max_ul_per_day_ip AS (
+  SELECT 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    ip,
+    MAX(mbps) AS mbps
+  FROM ul_per_location_cleaned
+  GROUP BY 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    ip
+),
+# Count the samples
+ul_sample_counts AS (
+  SELECT 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    COUNT(*) AS samples
+  FROM max_ul_per_day_ip
+  GROUP BY
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1  
+),
+# Count the samples that fall into each bucket
+ul_histogram_counts AS (
+  SELECT 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    bucket_left AS bucket_min,
+    bucket_right AS bucket_max,
+    COUNTIF(mbps < bucket_right AND mbps >= bucket_left) AS bucket_count
+  FROM max_ul_per_day_ip CROSS JOIN buckets
+  GROUP BY 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1,
+    bucket_min,
+    bucket_max
+),
+# Turn the counts into frequencies
+ul_histogram AS (
+  SELECT 
+    test_date,
+    continent_code,
+    country_code,
+    country_name,
+    ISO3166_2region1, 
+    bucket_min,
+    bucket_max,
+    bucket_count / samples AS ul_frac,
+    samples AS ul_samples
+  FROM ul_histogram_counts 
+  JOIN ul_sample_counts USING (test_date, continent_code, country_code,
+                            country_name, ISO3166_2region1)
+)
+# Show the results
+SELECT * FROM dl_histogram
+JOIN ul_histogram USING (test_date, continent_code, country_code, country_name, ISO3166_2region1, bucket_min, bucket_max)
+JOIN dl_stats_per_day USING (test_date, continent_code, country_code, country_name, ISO3166_2region1)
+JOIN dl_total_samples_per_geo USING (test_date, continent_code, country_code, country_name, ISO3166_2region1)
+JOIN ul_stats_per_day USING (test_date, continent_code, country_code, country_name, ISO3166_2region1)
+JOIN ul_total_samples_per_geo USING (test_date, continent_code, country_code, country_name, ISO3166_2region1)
+ORDER BY test_date, continent_code, country_code, country_name, ISO3166_2region1, bucket_min, bucket_max

--- a/statistics/queries/get_continent_country_region_codes.sql
+++ b/statistics/queries/get_continent_country_region_codes.sql
@@ -1,0 +1,11 @@
+SELECT 
+  client.geo.continent_code AS continent_code,
+  client.geo.country_code AS country_code,
+  client.Geo.region AS ISO3166_2region1
+FROM `ndt.unified_downloads`
+WHERE test_date >= '2020-01-01'
+AND client.geo.continent_code IS NOT NULL AND client.geo.continent_code != ''
+AND client.geo.country_code IS NOT NULL AND client.geo.country_code != ''
+AND client.Geo.region IS NOT NULL AND client.Geo.region != ''
+GROUP BY continent_code, country_code, ISO3166_2region1
+ORDER BY continent_code, country_code, ISO3166_2region1

--- a/statistics/scripts/update_stats_continent_country_region_histogram.sh
+++ b/statistics/scripts/update_stats_continent_country_region_histogram.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+set -eux
+
+PROJECT="measurement-lab"
+USERNAME="critzo"
+PUB_LOC="api.measurementlab.net"
+
+# Initially set the project to measurement-lab.
+gcloud config set project measurement-lab
+
+declare -a query_jobs=("continent_country_region_histogram")
+
+#########################
+# Set date parameters for this run.  
+# Two options: - Check the exising table for the last date in the table
+#              - Set specific start & end dates
+#
+#   Comment out the option you don't want to use
+
+### option 1
+#today=($(TZ=GMT date +"%Y-%m-%d"))
+#sixmonths=$(TZ=GMT date -I -d "$today - 6 month")
+
+# Get the last date in the appropriate stats table from the last run.
+#JOB_ID0=$(bq --format=json --nosync --project_id "${PROJECT}" query \
+#  "SELECT test_date FROM \`measurement-lab.mlab_statistics.continent_country_region_histogram\` WHERE test_date >= \"${sixmonths}\" ORDER BY test_date DESC LIMIT 1") > lastdate.json
+
+#JOB_ID0="${JOB_ID0#Successfully started query }"
+
+#until [ DONE == $(bq --format json show --job "${JOB_ID0}" | jq -r '.status.state') ]
+#do
+#  sleep 30
+#done
+
+#lastday=($(jq .[].test_date lastdate.json))
+
+# Set startday to -2 days from last date.
+#   This ensures we've got all data from that day, as previous runs may have missed 
+#   tests that hadn't been pushed or were reprocessed since the last time.
+#
+#startday=$(TZ=GMT date -I -d "$lastday - 2 day")
+
+# Set end day to -4 days from today. 
+#   This ensures we're processing days where ETL has likely published most test data already.
+#
+#endday=$(TZ=GMT date -I -d "$today - 4 day")
+
+## When running option 1, automatic date selection:
+#     - first we'll delete any data between startday and endday
+#     - this ensures we are reprocessing all recent days to account for test rows 
+#       that might have been added since the last run by pusher or re-processed by gardener
+
+#JOB_ID1=$(bq --nosync --project_id "${PROJECT}" query \
+#  --use_legacy_sql=false "DELETE FROM \`measurement-lab.mlab_statistics.continent_country_region_histogram\` WHERE test_date BETWEEN \"${startday}\" AND \"${endday}\"")
+
+#JOB_ID1="${JOB_ID1#Successfully started query }"
+
+#until [ DONE == $(bq --format json show --job "${JOB_ID1}" | jq -r '.status.state') ]
+#do
+#  sleep 30
+#done
+
+
+### option 2
+startday=2019-01-01
+endday=2019-12-31
+#########################
+
+# Set the start and end year so we can group output by year
+startarray=($(echo $startday | tr "-" "\n"))
+startyear=${startarray[0]}
+endarray=($(echo $endday | tr "-" "\n"))
+endyear=${endarray[0]}
+endyear=$((endyear+1))
+
+year_range=()
+year_range+=(${startyear})
+
+if [ "$startyear" != "$endyear" ]
+then 
+  while [ "$startyear" != "$endyear" ]; do
+    startyear=$((startyear+1))
+    year_range+=(${startyear})
+  done
+fi
+
+for val in ${query_jobs[@]}; do
+  RESULT_NAME="$val"
+  QUERY="${RESULT_NAME}.sql"
+  QUALIFIED_TABLE="${PROJECT}:mlab_statistics.${RESULT_NAME}"
+
+  # Run bq query with generous row limit. Write results to temp table created above.
+  # By default, bq fetches the query results to display in the shell, consuming a lot of memory.
+  # Use --nosync to "fire-and-forget", then implement our own wait loop to defer the next command
+  # until the table is populated.
+
+  while [ "$startday" != "$endday" ]; do
+    JOB_ID=$(bq --nosync --project_id "${PROJECT}" query \
+      --parameter=startday::$startday --allow_large_results --destination_table "${QUALIFIED_TABLE}" \
+      --append_table --use_legacy_sql=false --max_rows=4000000 \
+      "$(cat "queries/${QUERY}")")
+
+    JOB_ID="${JOB_ID#Successfully started query }"
+
+    until [ DONE == $(bq --format json show --job "${JOB_ID}" | jq -r '.status.state') ]
+    do
+      sleep 30
+    done
+
+    startday=$(date -I -d "$startday + 1 day")
+  done
+
+  # Automate stats and outputs by continent, country, region, etc. using query params.
+  #   Get all combinations of continent, country, and region codes & save to a local csv.
+
+## TODO: need to output daily counts by geo by YEAR. 
+##       probably should make /YYYY/ the final GCS path.
+  declare -a location_combos_query=("get_continent_country_region_codes")
+
+  for v in ${location_combos_query[@]}; do
+    RESULT2_NAME="$v"
+    QUERY2="${RESULT2_NAME}.sql"
+
+    JOB_ID2=$(bq --format=csv --project_id "${PROJECT}" query \
+    --use_legacy_sql=false --max_rows=4000000 \
+    "$(cat "queries/${QUERY2}")" > continent_country_region_codes.csv ) 
+  done
+
+  # bq exports csvs with a header. remove the header.
+  sed -i '1d' continent_country_region_codes.csv
+
+  # Make a temporary GCS bucket to store results.
+  gsutil mb gs://temp_stats_continent_country_region
+
+  # Grab the stats generated in bulk above, by year
+  for year in "${year_range[@]}"; do
+
+    # Loop through the csv lines, using three values as query parameters for a series of queries.
+    while IFS=, read -r continent country region;
+    do  
+      iso_region="$country-$region"
+
+      JOB_ID3=$(bq --nosync query \
+      --use_legacy_sql=false --max_rows=4000000 --allow_large_results \
+      --destination_table "mlab_statistics.temp_continent_country_region_stats" \
+      --replace "SELECT * FROM \`mlab_statistics.continent_country_region_histogram\` WHERE continent_code = \"${continent}\" AND country_code = \"${country}\" AND ISO3166_2region1 = \"${iso_region}\" ORDER BY test_date, continent_code, county_code, country_name, ISO3166_2region1, bucket_min, bucket_max, frac, samples")
+
+      JOB_ID3="${JOB_ID3#Successfully started query }"
+
+      until [ DONE == $(bq --format json show --job "${JOB_ID3}" | jq -r '.status.state') ]
+      do
+        sleep 30
+      done
+
+      # Extract the rows to JSON and/or other output formats      
+      bq extract --destination_format NEWLINE_DELIMITED_JSON \
+        mlab_statistics.temp_continent_country_region_stats \
+        gs://temp_stats_continent_country_region/${continent}/${country}/${region}/${year}/histogram_daily_stats.json      
+
+    done < continent_country_region_codes.csv
+
+  done
+
+  # Copy the full list of generated stats from measurement-lab project temp GCS bucket
+  gsutil -m cp -r gs://temp_stats_continent_country_region/* ./tmp/
+
+  # Change to production project and copy generated stats to the public bucket.
+  gcloud config set project mlab-oti
+
+  # Convert all new line json files to json array format
+  find ./tmp/ -type f -exec sed -i '1s/^/[/; $!s/$/,/; $s/$/]/' {} +
+
+  # Publish the json array files to public GCS bucket
+  gsutil -m cp -r ./tmp/* gs://${PUB_LOC}/
+
+  # Change back to the measurement-lab project for the next iteration.
+  gcloud config set project measurement-lab
+
+done
+
+# Cleanup 
+## Remove the temporary GCS bucket.
+gsutil rm -r gs://temp_stats_continent_country_region
+
+## Remove local copies.
+rm -r ./tmp/*
+rm continent_country_region_codes.csv


### PR DESCRIPTION
This PR adds the queries and shell script that produces:
* Daily histograms and statistics for each continent-country-region geography over a selected date range
  * Results saved in: `measurement-lab.mlab_statistics.continent_country_region_histogram`
  * JSON format output in a public GCS bucket following this pattern:
    * `/ <continent_code> / <country_code> / <region_code> / <year> / histogram_daily_stats.json`